### PR TITLE
Added deeplink support for opening a place from a coordinate

### DIFF
--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.h
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.h
@@ -1,4 +1,5 @@
 @import Foundation;
+@import CoreLocation;
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSUInteger, WMFUserActivityType) {
@@ -45,6 +46,10 @@ extern NSString *const WMFNavigateToActivityNotification;
 - (nullable NSString *)wmf_searchTerm;
 
 - (nullable NSURL *)wmf_linkURL;
+
+- (nullable NSString *)wmf_locationTitle;
+
+- (nullable CLLocation *)wmf_location;
 
 - (NSURL *)wmf_contentURL;
 

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1188,11 +1188,18 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
             [self dismissPresentedViewControllers];
             [self setSelectedIndex:WMFAppTabTypePlaces];
             [self.navigationController popToRootViewControllerAnimated:animated];
+            
+            // For "View on a map" action to succeed, view mode has to be set to map.
+            [[self placesViewController] updateViewModeToMap];
+            
             NSURL *articleURL = activity.wmf_linkURL;
             if (articleURL) {
-                // For "View on a map" action to succeed, view mode has to be set to map.
-                [[self placesViewController] updateViewModeToMap];
                 [[self placesViewController] showArticleURL:articleURL];
+            } else {
+                CLLocation *location = activity.wmf_location;
+                NSString *title = activity.wmf_locationTitle;
+                
+                [[self placesViewController] showLocation:location withTitle:title];
             }
         } break;
         case WMFUserActivityTypeContent: {

--- a/WikipediaUnitTests/Code/NSUserActivity+WMFExtensionsTest.m
+++ b/WikipediaUnitTests/Code/NSUserActivity+WMFExtensionsTest.m
@@ -44,6 +44,39 @@
     XCTAssertEqual(activity.wmf_type, WMFUserActivityTypeSavedPages);
 }
 
+- (void)testPlacesWithArticleURL {
+    NSURL *articleURL = [NSURL URLWithString:@"https://en.m.wikipedia.org/wiki/Utrecht"];
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"wikipedia://places?WMFArticleURL=%@", articleURL.absoluteString]];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertEqualObjects(activity.wmf_linkURL, articleURL);
+}
+
+- (void)testPlacesWithCoordinateAndTitleURL {
+    CLLocationDegrees latitude = 52.090833;
+    CLLocationDegrees longitude = 5.121667;
+    NSString *title = @"Utrecht";
+    
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"wikipedia://places?coordinate=%f,%f&title=%@", latitude, longitude, title]];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertEqual(activity.wmf_location.coordinate.latitude, latitude);
+    XCTAssertEqual(activity.wmf_location.coordinate.longitude, longitude);
+    XCTAssertEqualObjects(activity.wmf_locationTitle, title);
+}
+
+- (void)testPlacesWithCoordinateURL {
+    CLLocationDegrees latitude = 52.090833;
+    CLLocationDegrees longitude = 5.121667;
+    
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"wikipedia://places?coordinate=%f,%f", latitude, longitude]];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertEqual(activity.wmf_location.coordinate.latitude, latitude);
+    XCTAssertEqual(activity.wmf_location.coordinate.longitude, longitude);
+    XCTAssertNil(activity.wmf_locationTitle);
+}
+
 - (void)testSearchURL {
     NSURL *url = [NSURL URLWithString:@"wikipedia://en.wikipedia.org/w/index.php?search=dog"];
     NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];

--- a/docs/url_schemes.md
+++ b/docs/url_schemes.md
@@ -9,6 +9,7 @@ The URL scheme is `wikipedia://`. The following URLs are currently handled:
 | Content            | wikipedia://content                      |                                          |
 | Explore            | wikipedia://explore                      |                                          |
 | History            | wikipedia://history                      |                                          |
-| Places             | wikipedia://places[?WMFArticleURL=]      |                                          |
+| Places from article             | wikipedia://places[?WMFArticleURL=]      |    wikipedia://places?WMFArticleURL=https://en.m.wikipedia.org/wiki/Utrecht                                      |
+| Places from coordinate             | wikipedia://places[?coordinate=title=]      |    wikipedia://places?coordinate=52.090833,5.121667&title=Utrecht wikipedia://places?coordinate=52.090833,5.121667                                    |
 | Saved pages        | wikipedia://saved                        |                                          |
 | Search             | wikipedia://[site]/w/index.php?search=[query] | wikipedia://en.wikipedia.org/w/index.php?search=dog |


### PR DESCRIPTION
Added deeplink support for opening a place from a coordinate with an optional title.

Examples: 

- wikipedia://places?coordinate=52.090833,5.121667
- wikipedia://places?coordinate=52.090833,5.121667&title=Utrecht